### PR TITLE
🐛 FIX:  Typo

### DIFF
--- a/packages/create-guten-block/app/prePrint.js
+++ b/packages/create-guten-block/app/prePrint.js
@@ -14,7 +14,7 @@ module.exports = ( blockName, blockDir ) => {
 	console.log(
 		'📦 ',
 		chalk.black.bgYellow(
-			` Creating a WP Gutenberg Block plguin called: ${ chalk.bgGreen(
+			` Creating a WP Gutenberg Block plugin called: ${ chalk.bgGreen(
 				` ${ blockName } `
 			) }\n`
 		),


### PR DESCRIPTION
Just corrected a spelling mistake — plguin to plugin — in `/packages/create-guten-block/app/prePrint.js` 🔥