### PR TITLE
📦 NEW: Providing warning on invalid block name — FIX #28

### DIFF
--- a/packages/create-guten-block/app/cli.js
+++ b/packages/create-guten-block/app/cli.js
@@ -10,6 +10,7 @@ const chalk = require( 'chalk' );
 const commander = require( 'commander' );
 const maybeEnvInfo = require( './envInfo' );
 const noBlockName = require( './noBlockName' );
+const invalidBlockName = require( './invalidBlockName' );
 const packageJson = require( '../package.json' );
 
 // Commander.js program.
@@ -52,6 +53,12 @@ module.exports = () => {
 		.toLowerCase()
 		.split( ' ' )
 		.join( '-' );
+
+	// Check if block name is valid
+	const blockNameRegex = /^[a-z][a-z0-9-]/;
+	if ( ! blockNameRegex.test( formatBlockName ) ) {
+		invalidBlockName();
+	}
 
 	return formatBlockName;
 };

--- a/packages/create-guten-block/app/cli.js
+++ b/packages/create-guten-block/app/cli.js
@@ -54,7 +54,7 @@ module.exports = () => {
 		.split( ' ' )
 		.join( '-' );
 
-	// Check if block name is valid
+	// Check if block name is valid.
 	const blockNameRegex = /^[a-z][a-z0-9-]/;
 	if ( ! blockNameRegex.test( formatBlockName ) ) {
 		invalidBlockName();

--- a/packages/create-guten-block/app/invalidBlockName.js
+++ b/packages/create-guten-block/app/invalidBlockName.js
@@ -1,0 +1,22 @@
+/**
+ * Handle if there's block name is not valid.
+ */
+
+'use strict';
+
+const chalk = require( 'chalk' );
+
+module.exports = () => {
+	// Stop if given block name is not valid.
+	console.log(
+		'\n❌ ',
+		chalk.black.bgRed( ' Please provide a valid block name: \n' )
+	);
+	console.log(
+		`  ${ chalk.dim( 'Block name must include only alphanumeric characters, numbers, dashes.' ) }`
+	);
+	console.log(
+		`  ${ chalk.dim( 'Block name must start with a letter.' ) }`
+	);
+	process.exit( 1 );
+};

--- a/packages/create-guten-block/app/invalidBlockName.js
+++ b/packages/create-guten-block/app/invalidBlockName.js
@@ -13,10 +13,11 @@ module.exports = () => {
 		chalk.black.bgRed( ' Please provide a valid block name: \n' )
 	);
 	console.log(
-		`  ${ chalk.dim( 'Block name must include only alphanumeric characters, numbers, dashes.' ) }`
+		`${ chalk.dim(
+			'⚠️  A block name can only contain lowercase alphanumeric characters and dashes.'
+		) }`
 	);
-	console.log(
-		`  ${ chalk.dim( 'Block name must start with a letter.' ) }`
-	);
+	console.log( `${ chalk.dim( '⚠️  A block name must begin with a letter.' ) }` );
+	console.log();
 	process.exit( 1 );
 };


### PR DESCRIPTION
This PR tries to approach issue [#28](https://github.com/ahmadawais/create-guten-block/issues/28).

To be on the safe side and cover all possible scenarios I started with checking where the user provided `blockName` is used and what are the limitations of each case:

1. PHP function names:

> A valid function name starts with a letter or underscore, 
> followed by any number of letters, numbers, or underscores. [(PHP Manual)](http://php.net/manual/en/functions.user-defined.php)

2. [Gutenberg's](https://github.com/WordPress/gutenberg/blob/master/blocks/api/registration.js) `registerBlockType` function `name` argument:
'Block names must (...) include only lowercase alphanumeric characters or dashes,
and start with a letter.'

3. `wp_enqueue_script` [handle:](https://developer.wordpress.org/reference/functions/wp_enqueue_script/) - it simply has to be a non-empty string

4. Gutenberg's block title - it has to be a non-empty string too

5. Suffix for `.wp-block-cgb-block-${blockName}` CSS class:
> In CSS, identifiers (including element names, classes, and IDs in selectors) 
> can contain only the characters [a-zA-Z0-9] and ISO 10646 characters U+00A0 and higher,
> plus the hyphen (-) and the underscore (_)" [(W3C)](https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier) 

Now, when we sum up all the above we can come to a conclusion that:

- `blockName`'s first character has to be a letter.
- `blockName` can contain spaces (ie: 'my awesome block') as they will be replaced by hyphens.
- `blockName` can contain uppercase letters as it will be converted to lowercase anyway.
- `blockName` shouldn't contain underscores(_) as they are valid in php, but will cause errors when we are trying to register our block
- starting with 2nd character: `blockName` can contain dashes (-) [thanks to: `<% blockNamePHPLower %>`]

Having this in mind I think that following regex should suffice to do the job: `/^[a-z][a-z0-9-]/`

As I mentioned spaces and uppercase letters are filtered anyway, so I think it's better to put the code after the formatting `blockName` instead of adding it into regex.

Wow, quite a long output for such a short regex, but hopefully it's good enough.

Cheers 🍻