### PR TITLE
👌 IMPROVE: 'save' function props

### DIFF
--- a/packages/cgb-scripts/template/src/block/block.js
+++ b/packages/cgb-scripts/template/src/block/block.js
@@ -74,7 +74,7 @@ registerBlockType( 'cgb/block-<% blockName %>', {
 	 */
 	save: function( props ) {
 		return (
-			<div className={ props.className }>
+			<div>
 				<p>— Hello from the frontend.</p>
 				<p>
 					CGB BLOCK: <code><% blockName %></code> is a new Gutenberg block.


### PR DESCRIPTION
The purpose of this PR is to remove `className={ props.className }` from 'save' function from block.js file.

Resolves ahmadawais/create-guten-block#45 