### PR TITLE
Output the script tag in the footer

### DIFF
--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -47,8 +47,9 @@ function <% blockNamePHPLower %>_cgb_editor_assets() {
 	wp_enqueue_script(
 		'<% blockNamePHPLower %>-cgb-block-js', // Handle.
 		plugins_url( '/dist/blocks.build.js', dirname( __FILE__ ) ), // Block.build.js: We register the block here. Built with Webpack.
-		array( 'wp-blocks', 'wp-i18n', 'wp-element' ) // Dependencies, defined above.
-		// filemtime( plugin_dir_path( __FILE__ ) . 'block.js' ) // Version: filemtime — Gets file modification time.
+		array( 'wp-blocks', 'wp-i18n', 'wp-element' ), // Dependencies, defined above.
+		'', // filemtime( plugin_dir_path( __FILE__ ) . 'block.js' ) // Version: filemtime — Gets file modification time.
+		true
 	);
 
 	// Styles.


### PR DESCRIPTION
Fixes a bug where Gutenberg crashes if you add `wp-edit-post` as a dependency of the enqueued script.

## Testing instructions

* Add `wp-edit-post` to the dependencies of the script.
* Open Gutenberg, see that it crashes.
* Apply this PR.
* Re-add `wp-edit-post` to the dependencies of the script.
* Open Gutenberg, see that it doesn't crash.