### PR TITLE
📦 NEW: `init` hook to enqueue block scripts

### DIFF
--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -4,7 +4,7 @@
  *
  * Enqueue CSS/JS of all the blocks.
  *
- * @since 	1.0.0
+ * @since   1.0.0
  * @package CGB
  */
 
@@ -17,33 +17,21 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Enqueue Gutenberg block assets for both frontend + backend.
  *
  * `wp-blocks`: includes block type registration and related functions.
+ * `wp-element`: includes the WordPress Element abstraction for describing the structure of your blocks.
+ * `wp-i18n`: To internationalize the block's text.
  *
  * @since 1.0.0
  */
 function <% blockNamePHPLower %>_cgb_block_assets() {
-	// Styles.
+	// Block frontend styles.
 	wp_enqueue_style(
 		'<% blockNamePHPLower %>-cgb-style-css', // Handle.
 		plugins_url( 'dist/blocks.style.build.css', dirname( __FILE__ ) ), // Block style CSS.
 		array( 'wp-blocks' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __FILE__ ) . 'editor.css' ) // Version: filemtime — Gets file modification time.
 	);
-} // End function <% blockNamePHPLower %>_cgb_block_assets().
 
-// Hook: Frontend assets.
-add_action( 'enqueue_block_assets', '<% blockNamePHPLower %>_cgb_block_assets' );
-
-/**
- * Enqueue Gutenberg block assets for backend editor.
- *
- * `wp-blocks`: includes block type registration and related functions.
- * `wp-element`: includes the WordPress Element abstraction for describing the structure of your blocks.
- * `wp-i18n`: To internationalize the block's text.
- *
- * @since 1.0.0
- */
-function <% blockNamePHPLower %>_cgb_editor_assets() {
-	// Scripts.
+	// Block scripts.
 	wp_enqueue_script(
 		'<% blockNamePHPLower %>-cgb-block-js', // Handle.
 		plugins_url( '/dist/blocks.build.js', dirname( __FILE__ ) ), // Block.build.js: We register the block here. Built with Webpack.
@@ -51,14 +39,26 @@ function <% blockNamePHPLower %>_cgb_editor_assets() {
 		// filemtime( plugin_dir_path( __FILE__ ) . 'block.js' ) // Version: filemtime — Gets file modification time.
 	);
 
-	// Styles.
+	// Block backend styles.
 	wp_enqueue_style(
 		'<% blockNamePHPLower %>-cgb-block-editor-css', // Handle.
 		plugins_url( 'dist/blocks.editor.build.css', dirname( __FILE__ ) ), // Block editor CSS.
 		array( 'wp-edit-blocks' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __FILE__ ) . 'editor.css' ) // Version: filemtime — Gets file modification time.
 	);
-} // End function <% blockNamePHPLower %>_cgb_editor_assets().
 
-// Hook: Editor assets.
-add_action( 'enqueue_block_editor_assets', '<% blockNamePHPLower %>_cgb_editor_assets' );
+	/**
+	 * Register the block scripts and styles on server-side
+	 * to ensure they are enqueued when the editor loads.
+	 *
+	 * @link https://wordpress.org/gutenberg/handbook/blocks/writing-your-first-block-type/
+	 */
+	register_block_type( 'cgb/block-<% blockName %>', array(
+		'style' => '<% blockNamePHPLower %>-cgb-style-css',
+		'editor_script' => '<% blockNamePHPLower %>-cgb-block-js',
+		'editor_style' => '<% blockNamePHPLower %>-cgb-block-editor-css',
+	) );
+} // End function <% blockNamePHPLower %>_cgb_block_assets().
+
+// Hook: Block assets.
+add_action( 'init', '<% blockNamePHPLower %>_cgb_block_assets' );

--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -48,15 +48,15 @@ function <% blockNamePHPLower %>_cgb_block_assets() {
 	);
 
 	/**
-	 * Register the block scripts and styles on server-side
-	 * to ensure they are enqueued when the editor loads.
+	 * Register the block scripts and styles for both frontend and
+	 * backend to ensure they are enqueued when the editor loads.
 	 *
 	 * @link https://wordpress.org/gutenberg/handbook/blocks/writing-your-first-block-type/
 	 */
 	register_block_type( 'cgb/block-<% blockName %>', array(
-		'style' => '<% blockNamePHPLower %>-cgb-style-css',
-		'editor_script' => '<% blockNamePHPLower %>-cgb-block-js',
-		'editor_style' => '<% blockNamePHPLower %>-cgb-block-editor-css',
+		'style' => '<% blockNamePHPLower %>-cgb-style-css', // Enqueue blocks.style.build.css on both frontend & backend.
+		'editor_script' => '<% blockNamePHPLower %>-cgb-block-js', // Enqueue blocks.build.js in the editor only.
+		'editor_style' => '<% blockNamePHPLower %>-cgb-block-editor-css', // Enqueue blocks.editor.build.css in the editor only.
 	) );
 } // End function <% blockNamePHPLower %>_cgb_block_assets().
 

--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0
  */
 function <% blockNamePHPLower %>_cgb_block_assets() {
-	// Block frontend styles.
+	// Styles.
 	wp_enqueue_style(
 		'<% blockNamePHPLower %>-cgb-style-css', // Handle.
 		plugins_url( 'dist/blocks.style.build.css', dirname( __FILE__ ) ), // Block style CSS.


### PR DESCRIPTION
Hey 🙌

After reading the discussing in issue ahmadawais/create-guten-block#37, I have done the appropriate changes to the code in `cgb-scripts/template/src/init.php` ✅ 

⚠️ Unfortunately, I was not able to test the changes. I followed @ahmadawais' pointer but it didn't work for me.

✔Sending the PR anyway, so that you can test the changes yourself.

→ The scripts are being enqueued using `init` WordPress hook.

![alt text](https://cl.ly/qq64/💯 "Screenshot")

Cheers 🤘