### PR TITLE
Added "externals" property to configuration with React and ReactDOM as external dependencies

### DIFF
--- a/packages/cgb-scripts/config/webpack.config.dev.js
+++ b/packages/cgb-scripts/config/webpack.config.dev.js
@@ -117,4 +117,9 @@ module.exports = {
 	plugins: [ blocksCSSPlugin, editBlocksCSSPlugin ],
 	stats: 'minimal',
 	// stats: 'errors-only',
+	// Add externals.
+	externals: {
+		'react': 'React',
+		'react-dom': 'ReactDOM',
+	},
 };

--- a/packages/cgb-scripts/config/webpack.config.prod.js
+++ b/packages/cgb-scripts/config/webpack.config.prod.js
@@ -145,4 +145,9 @@ module.exports = {
 	],
 	stats: 'minimal',
 	// stats: 'errors-only',
+	// Add externals.
+	externals: {
+		'react': 'React',
+		'react-dom': 'ReactDOM',
+	},
 };


### PR DESCRIPTION
In response to ahmadawais/create-guten-block#66  😄 

Manual test:
1. installed [React-Select](https://www.npmjs.com/package/react-select): `npm install react-select`
2. imported Select to block`import Select from 'react-select';` so that `<Select />` is available.
3. old config shows build error: " Failed to compile. ... Module not found: Can't resolve 'react' in ... "
3. building runs fine with new config 👍 
