### PR TITLE
📦 NEW: Add support for @wordpress imports

### DIFF
--- a/packages/cgb-scripts/config/webpack.config.dev.js
+++ b/packages/cgb-scripts/config/webpack.config.dev.js
@@ -68,6 +68,27 @@ const extractConfig = {
 	],
 };
 
+// Build the externals list from React and WordPress components
+const externals = {
+	"react": "React",
+	"react-dom": "ReactDOM"
+};
+const wpDependencies = [
+	"components",
+	"element",
+	"blocks",
+	"editor",
+	"utils",
+	"date",
+	"data",
+	"i18n"
+];
+wpDependencies.forEach(wpDependency => {
+	externals["@wordpress/" + wpDependency] = {
+		this: ["wp", wpDependency]
+	};
+});
+
 // Export configuration.
 module.exports = {
 	entry: {
@@ -118,8 +139,5 @@ module.exports = {
 	stats: 'minimal',
 	// stats: 'errors-only',
 	// Add externals.
-	externals: {
-		'react': 'React',
-		'react-dom': 'ReactDOM',
-	},
+	externals,
 };

--- a/packages/cgb-scripts/config/webpack.config.dev.js
+++ b/packages/cgb-scripts/config/webpack.config.dev.js
@@ -84,9 +84,7 @@ const wpDependencies = [
 	"i18n"
 ];
 wpDependencies.forEach(wpDependency => {
-	externals["@wordpress/" + wpDependency] = {
-		this: ["wp", wpDependency]
-	};
+	externals["@wordpress/" + wpDependency] = 'wp.' + name
 });
 
 // Export configuration.

--- a/packages/cgb-scripts/config/webpack.config.dev.js
+++ b/packages/cgb-scripts/config/webpack.config.dev.js
@@ -84,7 +84,7 @@ const wpDependencies = [
 	"i18n"
 ];
 wpDependencies.forEach(wpDependency => {
-	externals["@wordpress/" + wpDependency] = 'wp.' + name
+	externals["@wordpress/" + wpDependency] = 'wp.' + wpDependency
 });
 
 // Export configuration.

--- a/packages/cgb-scripts/config/webpack.config.prod.js
+++ b/packages/cgb-scripts/config/webpack.config.prod.js
@@ -88,9 +88,7 @@ const wpDependencies = [
 	"i18n"
 ];
 wpDependencies.forEach(wpDependency => {
-	externals["@wordpress/" + wpDependency] = {
-		this: ["wp", wpDependency]
-	};
+	externals["@wordpress/" + wpDependency] = 'wp.' + name
 });
 
 // Export configuration.

--- a/packages/cgb-scripts/config/webpack.config.prod.js
+++ b/packages/cgb-scripts/config/webpack.config.prod.js
@@ -72,6 +72,27 @@ const extractConfig = {
 	],
 };
 
+// Build the externals list from React and WordPress components
+const externals = {
+	"react": "React",
+	"react-dom": "ReactDOM"
+};
+const wpDependencies = [
+	"components",
+	"element",
+	"blocks",
+	"editor",
+	"utils",
+	"date",
+	"data",
+	"i18n"
+];
+wpDependencies.forEach(wpDependency => {
+	externals["@wordpress/" + wpDependency] = {
+		this: ["wp", wpDependency]
+	};
+});
+
 // Export configuration.
 module.exports = {
 	entry: {
@@ -146,8 +167,5 @@ module.exports = {
 	stats: 'minimal',
 	// stats: 'errors-only',
 	// Add externals.
-	externals: {
-		'react': 'React',
-		'react-dom': 'ReactDOM',
-	},
+	externals,
 };

--- a/packages/cgb-scripts/config/webpack.config.prod.js
+++ b/packages/cgb-scripts/config/webpack.config.prod.js
@@ -88,7 +88,7 @@ const wpDependencies = [
 	"i18n"
 ];
 wpDependencies.forEach(wpDependency => {
-	externals["@wordpress/" + wpDependency] = 'wp.' + name
+	externals["@wordpress/" + wpDependency] = 'wp.' + wpDependency
 });
 
 // Export configuration.


### PR DESCRIPTION
Improves ahmadawais/clai-old#59, fixes ahmadawais/create-guten-block#43.

This little patch provides support for the `import { … } from '@wordpress/…';` syntax. Tested on Win7 x64 with WordPress 3.9.6 and a slightly modified Columns block straight out of the Gutenberg github. Node 10.2.1, npm 5.6.0.

The main difference from the Gutenberg and the GCF exports, is that the syntax `externals["@wordpress/" + wpDependency] = { this: ["wp", wpDependency] };` would result in a lot of undefined errors at runtime, while `externals[ '@wordpress/${ name }' ] = 'wp.' + wpDependency` works as intended. Both compile equally fine, though.

An excerpt from the source I used for the component and a screen of it showing in the editor:

```js
edit( { attributes, setAttributes, className } ) {
  const { columns } = attributes;
  const classes = classnames( className, `has-${ columns }-columns` );

  return (
    <Fragment>
      <InspectorControls>
        <PanelBody>
          <RangeControl
            label={ __( 'Columns' ) }
            value={ columns }
            onChange={ ( nextColumns ) => {
              setAttributes( {
                columns: nextColumns,
              } );
            } }
            min={ 1 }
            max={ 6 }
          />
        </PanelBody>
      </InspectorControls>
      <div className={ classes }>
        <InnerBlocks layouts={ getColumnLayouts } />
      </div>
    </Fragment>
  );
},

save( { attributes } ) {
  const { columns } = attributes;

  return (
    <div className={ `has-${ columns }-columns` }>
      <InnerBlocks.Content />
    </div>
  );
},
```

![Component](https://user-images.githubusercontent.com/284077/40590734-30bdb48a-6204-11e8-8a96-cf68add30b4d.png)