### PR TITLE
🐛 FIX: Move block JS to footer

### DIFF
--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -47,7 +47,7 @@ function <% blockNamePHPLower %>_cgb_editor_assets() { // phpcs:ignore
 		'<% blockNamePHPLower %>-cgb-block-js', // Handle.
 		plugins_url( '/dist/blocks.build.js', dirname( __FILE__ ) ), // Block.build.js: We register the block here. Built with Webpack.
 		array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor' ), // Dependencies, defined above.
-		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.build.js' ), // Version: File modification time.
+		null, // filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.build.js' ), // Version: File modification time.
 		true // Enqueue the script in the footer.
 	);
 


### PR DESCRIPTION
Add a version number parameter (an empty string), which allows the
following parameter (`true`) to be properly interpreted as the
`in_footer` parameter.

See ahmadawais/create-guten-block#71

I'm having trouble using the modified template to generate the new block but I'm certain that is a separate problem in how I'm running my update (see ahmadawais/create-guten-block#73).  However, if it is easier to reject this PR and make the change yourself, that is no problem.
