### PR TITLE
[Idea][cgb-scripts] Move ownPackage to devDependencies on eject command

### DIFF
--- a/packages/cgb-scripts/scripts/eject.js
+++ b/packages/cgb-scripts/scripts/eject.js
@@ -189,6 +189,7 @@ inquirer
 
 		// Dependencies.
 		appPackage.dependencies = appPackage.dependencies || {};
+		appPackage.devDependencies = appPackage.devDependencies || {};
 		if ( appPackage.dependencies[ ownPackageName ] ) {
 			// Del cgb-scripts from dependencies now.
 			console.log( `  ➖  Removing ${ cyan( ownPackageName ) } from dependencies.` );
@@ -201,8 +202,8 @@ inquirer
 			// if ( ownPackage.optionalDependencies[ key ] ) {
 			// 	return;
 			// }
-			console.log( `  ➕  Adding ${ green( key ) } to dependencies.` );
-			appPackage.dependencies[ key ] = ownPackage.dependencies[ key ];
+			console.log( `  ➕  Adding ${ green( key ) } to devDependencies.` );
+			appPackage.devDependencies[ key ] = ownPackage.dependencies[ key ];
 		} );
 
 		// Sort the dependencies because we are that good :).


### PR DESCRIPTION
<!--
Thank you for sending a PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots! I mean that.

Happy contributing!
-->

Currently, eject command outputs cgb dependencies to the app dependencies. In my opinion, create-guten-block's dependencies are devDependencies of the app. This PR includes my idea of improving eject.

After modification, package.json(after eject) looks like this:

```
{
  "name": "eject-test-cgb-guten-block",
  "version": "1.0.0",
  "private": true,
  "scripts": {
    "start": "node scripts/start.js",
    "build": "node scripts/build.js"
  },
  "dependencies": {},
  "devDependencies": {
    "autoprefixer": "^7.2.4",
    "babel-core": "^6.25.0",
    "babel-eslint": "^8.2.1",
    "babel-loader": "^7.1.1",
    "babel-preset-cgb": "^1.4.0",
    "cgb-dev-utils": "^1.4.0",
    "chalk": "^2.3.0",
    "cross-env": "^5.0.1",
    "cross-spawn": "^5.1.0",
    "eslint": "^4.15.0",
    "eslint-config-wordpress": "^2.0.0",
    "eslint-plugin-jest": "^21.6.1",
    "eslint-plugin-jsx-a11y": "^6.0.3",
    "eslint-plugin-react": "^7.5.1",
    "eslint-plugin-wordpress": "^0.1.0",
    "extract-text-webpack-plugin": "^3.0.2",
    "filesize": "^3.5.11",
    "fs-extra": "^5.0.0",
    "gzip-size": "^4.1.0",
    "inquirer": "^5.0.0",
    "node-sass": "^4.7.2",
    "ora": "^1.3.0",
    "postcss-loader": "^2.0.10",
    "raw-loader": "^0.5.1",
    "resolve-pkg": "^1.0.0",
    "sass-loader": "^6.0.6",
    "shelljs": "^0.8.0",
    "style-loader": "^0.19.1",
    "update-notifier": "^2.3.0",
    "webpack": "^3.1.0"
  },
  "babel": {
    "presets": [
      [
        "env",
        {
          "modules": false,
          "targets": {
            "browsers": [
              "last 2 Chrome versions",
              "last 2 Firefox versions",
              "last 2 Safari versions",
              "last 2 iOS versions",
              "last 1 Android version",
              "last 1 ChromeAndroid version",
              "ie 11"
            ]
          }
        }
      ]
    ],
    "plugins": [
      [
        "transform-object-rest-spread"
      ],
      [
        "transform-object-rest-spread",
        {
          "useBuiltIns": true
        }
      ],
      [
        "transform-react-jsx",
        {
          "pragma": "wp.element.createElement"
        }
      ],
      [
        "transform-runtime",
        {
          "helpers": false,
          "polyfill": false,
          "regenerator": true
        }
      ]
    ]
  }
}
```

Screenshot:
<img width="476" alt="screen shot 2018-06-23 at 15 46 35" src="https://user-images.githubusercontent.com/1718007/41806735-621875f6-76fe-11e8-9a85-aef796a6bac7.png">
