### PR TITLE
FIX: Add missing commas to enqueue asset parameters

### DIFF
--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -25,7 +25,7 @@ function <% blockNamePHPLower %>_cgb_block_assets() {
 	wp_enqueue_style(
 		'<% blockNamePHPLower %>-cgb-style-css', // Handle.
 		plugins_url( 'dist/blocks.style.build.css', dirname( __FILE__ ) ), // Block style CSS.
-		array( 'wp-blocks' ) // Dependency to include the CSS after it.
+		array( 'wp-blocks' ), // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.style.build.css' ) // Version: filemtime — Gets file modification time.
 	);
 } // End function <% blockNamePHPLower %>_cgb_block_assets().
@@ -56,7 +56,7 @@ function <% blockNamePHPLower %>_cgb_editor_assets() {
 	wp_enqueue_style(
 		'<% blockNamePHPLower %>-cgb-block-editor-css', // Handle.
 		plugins_url( 'dist/blocks.editor.build.css', dirname( __FILE__ ) ), // Block editor CSS.
-		array( 'wp-edit-blocks' ) // Dependency to include the CSS after it.
+		array( 'wp-edit-blocks' ), // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.editor.build.css' ) // Version: filemtime — Gets file modification time.
 	);
 } // End function <% blockNamePHPLower %>_cgb_editor_assets().


### PR DESCRIPTION
If you uncomment the version parameter in either `wp_enqueue_style` function call it will trigger a fatal PHP error due to a missing comma after the dependencies parameter that precedes it. Adding these two commas fixes the error. 

<img width="1278" alt="screen shot 2018-09-06 at 11 49 32" src="https://user-images.githubusercontent.com/5252550/45150021-32967a00-b1cb-11e8-9843-bd299cfb5ce8.png">

<!--
Thank you for sending a PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots! I mean that.

Happy contributing!
-->
