### PR TITLE
📦 NEW: Add recommended .gitignore file on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Inside that directory, it will generate the initial project structure and instal
 ```sh
 INSIDE: /local_dev_site.tld/wp-content/plugins/my-block
 
+├── .gitignore
 ├── plugin.php
 ├── package.json
 ├── README.md

--- a/packages/create-guten-block/app/createGitignore.js
+++ b/packages/create-guten-block/app/createGitignore.js
@@ -13,7 +13,12 @@ module.exports = (blockDir) => {
 	shell.touch( '.gitignore' );
 
 	// Build a default .gitignore
-	const ignore = `node_modules\ndist/`;
+	const ignore = [
+		'node_modules\n',
+		'## Uncomment line below if you prefer to',
+		'## keep compiled files out of version control',
+		'# dist/'
+	].join('\n');
 
 	return new Promise( async resolve => {
 		await fs.writeFileSync(

--- a/packages/create-guten-block/app/createGitignore.js
+++ b/packages/create-guten-block/app/createGitignore.js
@@ -1,0 +1,25 @@
+/**
+ * Install a starter .gitignore
+ */
+
+'use strict';
+
+const path = require( 'path' );
+const fs = require( 'fs-extra' );
+const shell = require( 'shelljs' );
+
+module.exports = (blockDir) => {
+	shell.cd( blockDir );
+	shell.touch( '.gitignore' );
+
+	// Build a default .gitignore
+	const ignore = `node_modules\ndist/`;
+
+	return new Promise( async resolve => {
+		await fs.writeFileSync(
+			path.join( process.cwd(), '.gitignore' ),
+			ignore + '\n'
+		);
+		resolve( true );
+	} );
+};

--- a/packages/create-guten-block/app/createPluginDir.js
+++ b/packages/create-guten-block/app/createPluginDir.js
@@ -11,8 +11,9 @@ const chalk = require( 'chalk' );
 const shell = require( 'shelljs' );
 const clearConsole = require( './consoleClear' );
 const directoryExists = require( 'directory-exists' );
+const createGitignore = require( './createGitignore' );
 
-module.exports = blockName => {
+module.exports = ( blockName, blockDir ) => {
 	// Check if the plugin dir is already presnet.
 	const dirAlreadyExist = directoryExists.sync( `./${ blockName }` );
 
@@ -40,11 +41,11 @@ module.exports = blockName => {
 		);
 		process.exit( 1 );
 	} else {
-		return new Promise( resolve => {
+		return new Promise( async resolve => {
 			// Where user is at the moment.
-			shell.exec( `mkdir -p ${ blockName }`, () => {
-				resolve( true );
-			} );
+			shell.exec( `mkdir -p ${ blockName }` );
+			await createGitignore( blockDir );
+			resolve(true);
 		} );
 	}
 };

--- a/packages/create-guten-block/app/run.js
+++ b/packages/create-guten-block/app/run.js
@@ -16,6 +16,7 @@ const clearConsole = require( './consoleClear' );
 const updateNotifier = require( './updateNotifier' );
 const createPluginDir = require( './createPluginDir' );
 const npmInstallScripts = require( './npmInstallScripts' );
+const createGitignore = require( './createGitignore' );
 
 module.exports = async() => {
 	clearConsole();
@@ -26,7 +27,7 @@ module.exports = async() => {
 	// 1. Set the CLI and get the blockName.
 	const blockName = cli();
 
-	// 2. Build the block direcotry path.
+	// 2. Build the block directory path.
 	const blockDir = await getBlockDir( blockName );
 
 	// 2. Pre print.
@@ -42,6 +43,7 @@ module.exports = async() => {
 		) }`
 	);
 	await createPluginDir( blockName );
+	await createGitignore( blockDir );
 	spinner.succeed();
 
 	// 4. NPM install cgb-scripts.

--- a/packages/create-guten-block/app/run.js
+++ b/packages/create-guten-block/app/run.js
@@ -16,7 +16,6 @@ const clearConsole = require( './consoleClear' );
 const updateNotifier = require( './updateNotifier' );
 const createPluginDir = require( './createPluginDir' );
 const npmInstallScripts = require( './npmInstallScripts' );
-const createGitignore = require( './createGitignore' );
 
 module.exports = async() => {
 	clearConsole();
@@ -42,12 +41,10 @@ module.exports = async() => {
 			` ${ blockName } `
 		) }`
 	);
-	await createPluginDir( blockName );
-	await createGitignore( blockDir );
+	await createPluginDir( blockName, blockDir );
 	spinner.succeed();
 
 	// 4. NPM install cgb-scripts.
-
 	spinner.start( '2. Installing npm packages...' );
 	await npmInstallScripts( blockName, blockDir );
 	spinner.succeed();


### PR DESCRIPTION
As noted in ahmadawais/create-guten-block#72, a recommended `.gitignore` should be added when running create-guten-block for the first time, especially because users of cgb may be new to the concept of developing Javascript and the concept of keeping `node_modules` out of version control. 

The recommended `.gitignore` will keep npm packages out of version control, as well as compiled files in the `dist` directory.