### PR TITLE
🐛 FIX: Correct shelljs mkdir syntax

### DIFF
--- a/packages/create-guten-block/app/createPluginDir.js
+++ b/packages/create-guten-block/app/createPluginDir.js
@@ -43,7 +43,7 @@ module.exports = ( blockName, blockDir ) => {
 	} else {
 		return new Promise( async resolve => {
 			// Where user is at the moment.
-			shell.exec( `mkdir -p ${ blockName }` );
+			shell.mkdir( '-p', blockName );
 			await createGitignore( blockDir );
 			resolve(true);
 		} );


### PR DESCRIPTION
Update generation script to use correct [`mkdir` method](https://github.com/shelljs/shelljs#mkdiroptions-dir--dir-) on shelljs API. 

This was resolves ahmadawais/create-guten-block#67 and has been tested in Windows v10 environment. Result is no more `-p` directory is created.