### PR TITLE
FIX: wp.editor is undefined in latest version of gutenberg.

### DIFF
--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -47,7 +47,7 @@ function <% blockNamePHPLower %>_cgb_editor_assets() {
 	wp_enqueue_script(
 		'<% blockNamePHPLower %>-cgb-block-js', // Handle.
 		plugins_url( '/dist/blocks.build.js', dirname( __FILE__ ) ), // Block.build.js: We register the block here. Built with Webpack.
-		array( 'wp-blocks', 'wp-i18n', 'wp-element' ), // Dependencies, defined above.
+		array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor' ), // Dependencies, defined above.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.build.js' ), // Version: filemtime — Gets file modification time.
 		true // Enqueue the script in the footer.
 	);


### PR DESCRIPTION
wp.editor is undefined when using the latest version of Gutenberg. This fix makes sure the `wp.editor` is loaded before the cgb. plugin.

<!--
Thank you for sending a PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots! I mean that.

Happy contributing!
-->
