### PR TITLE
🐛 FIX: enqueue dependencies for WP5. (#107)

### DIFF
--- a/examples/01-single-block/src/init.php
+++ b/examples/01-single-block/src/init.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Enqueue Gutenberg block assets for both frontend + backend.
  *
- * `wp-blocks`: includes block type registration and related functions.
+ * `wp-editor`: WP editor styles.
  *
  * @since 1.0.0
  */
@@ -25,7 +25,7 @@ function single_block_cgb_block_assets() {
 	wp_enqueue_style(
 		'single_block-cgb-style-css', // Handle.
 		plugins_url( 'dist/blocks.style.build.css', dirname( __FILE__ ) ), // Block style CSS.
-		array( 'wp-blocks' ) // Dependency to include the CSS after it.
+		array( 'wp-editor' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.style.build.css' ) // Version: filemtime — Gets file modification time.
 	);
 } // End function single_block_cgb_block_assets().
@@ -36,9 +36,10 @@ add_action( 'enqueue_block_assets', 'single_block_cgb_block_assets' );
 /**
  * Enqueue Gutenberg block assets for backend editor.
  *
- * `wp-blocks`: includes block type registration and related functions.
+ * `wp-blocks`:  includes block type registration and related functions.
  * `wp-element`: includes the WordPress Element abstraction for describing the structure of your blocks.
- * `wp-i18n`: To internationalize the block's text.
+ * `wp-i18n`:    internationalize the block's text.
+ * `wp-editor`:  WP editor styles.
  *
  * @since 1.0.0
  */
@@ -47,7 +48,7 @@ function single_block_cgb_editor_assets() {
 	wp_enqueue_script(
 		'single_block-cgb-block-js', // Handle.
 		plugins_url( '/dist/blocks.build.js', dirname( __FILE__ ) ), // Block.build.js: We register the block here. Built with Webpack.
-		array( 'wp-blocks', 'wp-i18n', 'wp-element' ) // Dependencies, defined above.
+		array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor' ) // Dependencies, defined above.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.build.js' ) // Version: filemtime — Gets file modification time.
 	);
 

--- a/examples/02-single-block-ejected/src/init.php
+++ b/examples/02-single-block-ejected/src/init.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Enqueue Gutenberg block assets for both frontend + backend.
  *
- * `wp-blocks`: includes block type registration and related functions.
+ * `wp-editor`: WP editor styles.
  *
  * @since 1.0.0
  */
@@ -25,7 +25,7 @@ function single_block_cgb_block_assets() {
 	wp_enqueue_style(
 		'single_block-cgb-style-css', // Handle.
 		plugins_url( 'dist/blocks.style.build.css', dirname( __FILE__ ) ), // Block style CSS.
-		array( 'wp-blocks' ) // Dependency to include the CSS after it.
+		array( 'wp-editor' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.style.build.css' ) // Version: filemtime — Gets file modification time.
 	);
 } // End function single_block_cgb_block_assets().
@@ -36,9 +36,10 @@ add_action( 'enqueue_block_assets', 'single_block_cgb_block_assets' );
 /**
  * Enqueue Gutenberg block assets for backend editor.
  *
- * `wp-blocks`: includes block type registration and related functions.
+ * `wp-blocks`:  includes block type registration and related functions.
  * `wp-element`: includes the WordPress Element abstraction for describing the structure of your blocks.
- * `wp-i18n`: To internationalize the block's text.
+ * `wp-i18n`:    internationalize the block's text.
+ * `wp-editor`:  WP editor styles.
  *
  * @since 1.0.0
  */
@@ -47,7 +48,7 @@ function single_block_cgb_editor_assets() {
 	wp_enqueue_script(
 		'single_block-cgb-block-js', // Handle.
 		plugins_url( '/dist/blocks.build.js', dirname( __FILE__ ) ), // Block.build.js: We register the block here. Built with Webpack.
-		array( 'wp-blocks', 'wp-i18n', 'wp-element' ) // Dependencies, defined above.
+		array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor' ) // Dependencies, defined above.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.build.js' ) // Version: filemtime — Gets file modification time.
 	);
 

--- a/examples/03-multi-block/src/init.php
+++ b/examples/03-multi-block/src/init.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Enqueue Gutenberg block assets for both frontend + backend.
  *
- * `wp-blocks`: includes block type registration and related functions.
+ * `wp-editor`: WP editor styles.
  *
  * @since 1.0.0
  */
@@ -25,7 +25,7 @@ function multi_block_cgb_block_assets() {
 	wp_enqueue_style(
 		'multi_block-cgb-style-css', // Handle.
 		plugins_url( 'dist/blocks.style.build.css', dirname( __FILE__ ) ), // Block style CSS.
-		array( 'wp-blocks' ) // Dependency to include the CSS after it.
+		array( 'wp-editor' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.style.build.css' ) // Version: filemtime — Gets file modification time.
 	);
 } // End function multi_block_cgb_block_assets().
@@ -36,9 +36,10 @@ add_action( 'enqueue_block_assets', 'multi_block_cgb_block_assets' );
 /**
  * Enqueue Gutenberg block assets for backend editor.
  *
- * `wp-blocks`: includes block type registration and related functions.
+ * `wp-blocks`:  includes block type registration and related functions.
  * `wp-element`: includes the WordPress Element abstraction for describing the structure of your blocks.
- * `wp-i18n`: To internationalize the block's text.
+ * `wp-i18n`:    internationalize the block's text.
+ * `wp-editor`:  WP editor styles.
  *
  * @since 1.0.0
  */
@@ -47,7 +48,7 @@ function multi_block_cgb_editor_assets() {
 	wp_enqueue_script(
 		'multi_block-cgb-block-js', // Handle.
 		plugins_url( '/dist/blocks.build.js', dirname( __FILE__ ) ), // Block.build.js: We register the block here. Built with Webpack.
-		array( 'wp-blocks', 'wp-i18n', 'wp-element' ) // Dependencies, defined above.
+		array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor' ) // Dependencies, defined above.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.build.js' ) // Version: filemtime — Gets file modification time.
 	);
 

--- a/examples/04-multi-block-ejected/src/init.php
+++ b/examples/04-multi-block-ejected/src/init.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Enqueue Gutenberg block assets for both frontend + backend.
  *
- * `wp-blocks`: includes block type registration and related functions.
+ * `wp-editor`: WP editor styles.
  *
  * @since 1.0.0
  */
@@ -25,7 +25,7 @@ function multi_block_cgb_block_assets() {
 	wp_enqueue_style(
 		'multi_block-cgb-style-css', // Handle.
 		plugins_url( 'dist/blocks.style.build.css', dirname( __FILE__ ) ), // Block style CSS.
-		array( 'wp-blocks' ) // Dependency to include the CSS after it.
+		array( 'wp-editor' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.style.build.css' ) // Version: filemtime — Gets file modification time.
 	);
 } // End function multi_block_cgb_block_assets().
@@ -36,9 +36,10 @@ add_action( 'enqueue_block_assets', 'multi_block_cgb_block_assets' );
 /**
  * Enqueue Gutenberg block assets for backend editor.
  *
- * `wp-blocks`: includes block type registration and related functions.
+ * `wp-blocks`:  includes block type registration and related functions.
  * `wp-element`: includes the WordPress Element abstraction for describing the structure of your blocks.
- * `wp-i18n`: To internationalize the block's text.
+ * `wp-i18n`:    internationalize the block's text.
+ * `wp-editor`:  WP editor styles.
  *
  * @since 1.0.0
  */
@@ -47,7 +48,7 @@ function multi_block_cgb_editor_assets() {
 	wp_enqueue_script(
 		'multi_block-cgb-block-js', // Handle.
 		plugins_url( '/dist/blocks.build.js', dirname( __FILE__ ) ), // Block.build.js: We register the block here. Built with Webpack.
-		array( 'wp-blocks', 'wp-i18n', 'wp-element' ) // Dependencies, defined above.
+		array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor' ) // Dependencies, defined above.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.build.js' ) // Version: filemtime — Gets file modification time.
 	);
 

--- a/examples/05-a11y-input/src/init.php
+++ b/examples/05-a11y-input/src/init.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Enqueue Gutenberg block assets for both frontend + backend.
  *
- * `wp-blocks`: includes block type registration and related functions.
+ * `wp-editor`: WP editor styles.
  *
  * @since 1.0.0
  */
@@ -25,7 +25,7 @@ function a11y_input_cgb_block_assets() {
 	wp_enqueue_style(
 		'a11y_input-cgb-style-css', // Handle.
 		plugins_url( 'dist/blocks.style.build.css', dirname( __FILE__ ) ), // Block style CSS.
-		array( 'wp-blocks' ) // Dependency to include the CSS after it.
+		array( 'wp-editor' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.style.build.css' ) // Version: filemtime — Gets file modification time.
 	);
 } // End function a11y_input_cgb_block_assets().
@@ -36,9 +36,10 @@ add_action( 'enqueue_block_assets', 'a11y_input_cgb_block_assets' );
 /**
  * Enqueue Gutenberg block assets for backend editor.
  *
- * `wp-blocks`: includes block type registration and related functions.
+ * `wp-blocks`:  includes block type registration and related functions.
  * `wp-element`: includes the WordPress Element abstraction for describing the structure of your blocks.
- * `wp-i18n`: To internationalize the block's text.
+ * `wp-i18n`:    internationalize the block's text.
+ * `wp-editor`:  WP editor styles.
  *
  * @since 1.0.0
  */
@@ -47,7 +48,7 @@ function a11y_input_cgb_editor_assets() {
 	wp_enqueue_script(
 		'a11y_input-cgb-block-js', // Handle.
 		plugins_url( '/dist/blocks.build.js', dirname( __FILE__ ) ), // Block.build.js: We register the block here. Built with Webpack.
-		array( 'wp-blocks', 'wp-i18n', 'wp-element' ), // Dependencies, defined above.
+		array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor' ), // Dependencies, defined above.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.build.js' ), // Version: filemtime — Gets file modification time.
 		true // Enqueue the script in the footer.
 	);

--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Enqueue Gutenberg block assets for both frontend + backend.
  *
- * `wp-blocks`: includes block type registration and related functions.
+ * `wp-editor`: WP editor styles.
  *
  * @since 1.0.0
  */
@@ -25,7 +25,7 @@ function <% blockNamePHPLower %>_cgb_block_assets() {
 	wp_enqueue_style(
 		'<% blockNamePHPLower %>-cgb-style-css', // Handle.
 		plugins_url( 'dist/blocks.style.build.css', dirname( __FILE__ ) ), // Block style CSS.
-		array( 'wp-blocks' ) // Dependency to include the CSS after it.
+		array( 'wp-editor' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.style.build.css' ) // Version: filemtime — Gets file modification time.
 	);
 } // End function <% blockNamePHPLower %>_cgb_block_assets().
@@ -36,9 +36,10 @@ add_action( 'enqueue_block_assets', '<% blockNamePHPLower %>_cgb_block_assets' )
 /**
  * Enqueue Gutenberg block assets for backend editor.
  *
- * `wp-blocks`: includes block type registration and related functions.
+ * `wp-blocks`:  includes block type registration and related functions.
  * `wp-element`: includes the WordPress Element abstraction for describing the structure of your blocks.
- * `wp-i18n`: To internationalize the block's text.
+ * `wp-i18n`:    internationalize the block's text.
+ * `wp-editor`:  WP editor styles.
  *
  * @since 1.0.0
  */


### PR DESCRIPTION
I've updated the dependencies on enqueue functions in order to make it work with WP5 RC.

Styles are now loading well.

It's my first PR, please double-check my work
Also, I'm waiting an answer from the official Gut staff to be sure than theses dependencies are the right ones : maybe I'll publish another one soon, but right now the issue is fixed

The documentation about this is on wp.org is 404.

