### PR TITLE
Add option to enqueue frontend and frontend-only scripts

### DIFF
--- a/packages/cgb-scripts/config/paths.js
+++ b/packages/cgb-scripts/config/paths.js
@@ -16,6 +16,8 @@ module.exports = {
 	dotenv: resolvePlugin( '.env' ),
 	pluginSrc: resolvePlugin( 'src' ), // Plugin src folder path.
 	pluginBlocksJs: resolvePlugin( 'src/blocks.js' ),
+	pluginBlocksFrontJs: resolvePlugin( 'src/blocks.front.js' ),
+	pluginBlocksFrontOnlyJs: resolvePlugin( 'src/blocks.front-only.js' ),
 	yarnLockFile: resolvePlugin( 'yarn.lock' ),
 	pluginDist: resolvePlugin( '.' ), // We are in ./dist folder already so the path '.' resolves to ./dist/.
 };
@@ -29,6 +31,8 @@ module.exports = {
 	pluginSrc: resolvePlugin( 'src' ),
 	pluginBlocksJs: resolvePlugin( 'src/blocks.js' ),
 	pluginDist: resolvePlugin( '.' ), // We are in ./dist folder already so the path '.' resolves to ./dist/.
+	pluginBlocksFrontJs: resolvePlugin( 'src/blocks.front.js' ),
+	pluginBlocksFrontOnlyJs: resolvePlugin( 'src/blocks.front-only.js' ),
 	yarnLockFile: resolvePlugin( 'yarn.lock' ),
 	appPath: resolvePlugin( '.' ),
 	// These properties only exist before ejecting:

--- a/packages/cgb-scripts/config/webpack.config.dev.js
+++ b/packages/cgb-scripts/config/webpack.config.dev.js
@@ -73,6 +73,8 @@ const extractConfig = {
 module.exports = {
 	entry: {
 		'./dist/blocks.build': paths.pluginBlocksJs, // 'name' : 'path/file.ext'.
+		'./dist/blocks.front.build': paths.pluginBlocksFrontJs,
+		'./dist/blocks.front-only.build': paths.pluginBlocksFrontOnlyJs,
 	},
 	output: {
 		// Add /* filename */ comments to generated require()s in the output.

--- a/packages/cgb-scripts/config/webpack.config.prod.js
+++ b/packages/cgb-scripts/config/webpack.config.prod.js
@@ -77,6 +77,8 @@ const extractConfig = {
 module.exports = {
 	entry: {
 		'./dist/blocks.build': paths.pluginBlocksJs, // 'name' : 'path/file.ext'.
+		'./dist/blocks.front.build': paths.pluginBlocksFrontJs,
+		'./dist/blocks.front-only.build': paths.pluginBlocksFrontOnlyJs,
 	},
 	output: {
 		// Add /* filename */ comments to generated require()s in the output.

--- a/packages/cgb-scripts/template/src/block/block.front-only.js
+++ b/packages/cgb-scripts/template/src/block/block.front-only.js
@@ -1,8 +1,7 @@
 /**
  * BLOCK: <% blockName %>
  *
- * Script to be executed in the editor AND on the frontend.
- * 
+ * Script to be executed ONLY on the frontend, NOT in the editor.
  */
 
 console.log( 'Hi! This executes only on the frontend' );

--- a/packages/cgb-scripts/template/src/block/block.front-only.js
+++ b/packages/cgb-scripts/template/src/block/block.front-only.js
@@ -1,0 +1,8 @@
+/**
+ * BLOCK: <% blockName %>
+ *
+ * Script to be executed in the editor AND on the frontend.
+ * 
+ */
+
+console.log( 'Hi! This executes only on the frontend' );

--- a/packages/cgb-scripts/template/src/block/block.front.js
+++ b/packages/cgb-scripts/template/src/block/block.front.js
@@ -1,0 +1,8 @@
+/**
+ * BLOCK: <% blockName %>
+ *
+ * Script to be executed in the editor AND on the frontend.
+ * 
+ */
+
+console.log( 'Hi! This executes in the editor and on the frontend' );

--- a/packages/cgb-scripts/template/src/block/block.front.js
+++ b/packages/cgb-scripts/template/src/block/block.front.js
@@ -2,7 +2,6 @@
  * BLOCK: <% blockName %>
  *
  * Script to be executed in the editor AND on the frontend.
- * 
  */
 
 console.log( 'Hi! This executes in the editor and on the frontend' );

--- a/packages/cgb-scripts/template/src/blocks.front-only.js
+++ b/packages/cgb-scripts/template/src/blocks.front-only.js
@@ -1,9 +1,8 @@
 /**
  * Gutenberg Blocks
  *
- * All frontend blocks related JavaScript files should be imported here.
- * These scripts will be enqueued on the frontend AND in the editor.
- *
+ * All frontend-only blocks related JavaScript files should be imported here.
+ * These scripts will be enqueued ONLY on the frontend, NOT in the editor.
  */
 
 import './block/block.front-only.js';

--- a/packages/cgb-scripts/template/src/blocks.front-only.js
+++ b/packages/cgb-scripts/template/src/blocks.front-only.js
@@ -1,0 +1,9 @@
+/**
+ * Gutenberg Blocks
+ *
+ * All frontend blocks related JavaScript files should be imported here.
+ * These scripts will be enqueued on the frontend AND in the editor.
+ *
+ */
+
+import './block/block.front-only.js';

--- a/packages/cgb-scripts/template/src/blocks.front.js
+++ b/packages/cgb-scripts/template/src/blocks.front.js
@@ -1,0 +1,9 @@
+/**
+ * Gutenberg Blocks
+ *
+ * All frontend blocks related JavaScript files should be imported here.
+ * These scripts will be enqueued on the frontend AND in the editor.
+ *
+ */
+
+import './block/block.front.js';

--- a/packages/cgb-scripts/template/src/blocks.front.js
+++ b/packages/cgb-scripts/template/src/blocks.front.js
@@ -3,7 +3,6 @@
  *
  * All frontend blocks related JavaScript files should be imported here.
  * These scripts will be enqueued on the frontend AND in the editor.
- *
  */
 
 import './block/block.front.js';

--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -31,7 +31,6 @@ function <% blockNamePHPLower %>_cgb_block_assets() { // phpcs:ignore
 		array( 'wp-editor' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.style.build.css' ) // Version: File modification time.
 	);
-}
 
 	// Frontend Scripts. Loaded in frontend AND editor.
 	if ( $enable_front_JS ) {
@@ -54,6 +53,7 @@ function <% blockNamePHPLower %>_cgb_block_assets() { // phpcs:ignore
 			true // Enqueue the script in the footer.
 		);		
 	}
+};
 
 // Hook: Frontend assets.
 add_action( 'enqueue_block_assets', '<% blockNamePHPLower %>_cgb_block_assets' );

--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -20,6 +20,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0
  */
 function <% blockNamePHPLower %>_cgb_block_assets() { // phpcs:ignore
+	
+	$enable_front_JS = FALSE;
+	$enable_front_only_JS = FALSE;
+
 	// Styles.
 	wp_enqueue_style(
 		'<% blockNamePHPLower %>-cgb-style-css', // Handle.
@@ -28,6 +32,28 @@ function <% blockNamePHPLower %>_cgb_block_assets() { // phpcs:ignore
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.style.build.css' ) // Version: File modification time.
 	);
 }
+
+	// Frontend Scripts. Loaded in frontend AND editor.
+	if ( $enable_front_JS ) {
+		wp_enqueue_script(
+			'<% blockNamePHPLower %>-cgb-block-front-js', // Handle.
+			plugins_url( '/dist/blocks.front.build.js', dirname( __FILE__ ) ), // Block.build.js: We register the block here. Built with Webpack.
+			array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor' ), // Dependencies, defined above.
+			// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.build.js' ), // Version: File modification time.
+			true // Enqueue the script in the footer.
+		);
+	}
+
+	// Frontend ONLY Scripts.	NOT loaded in Editor.
+	if ( ! is_admin() && $enable_front_only_JS ) {
+		wp_enqueue_script(
+			'<% blockNamePHPLower %>-cgb-block-front-only.js', // Handle.
+			plugins_url( '/dist/blocks.front-only.build.js', dirname( __FILE__ ) ), // Block.build.js: We register the block here. Built with Webpack.
+			array( 'wp-editor' ), // Dependencies, defined above.
+			// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.build.js' ), // Version: File modification time.
+			true // Enqueue the script in the footer.
+		);		
+	}
 
 // Hook: Frontend assets.
 add_action( 'enqueue_block_assets', '<% blockNamePHPLower %>_cgb_block_assets' );


### PR DESCRIPTION
This is a solution to ahmadawais/create-guten-block#77.

I've added 2 additional scripts to the build process.

`block.front.js` - enqueued on the frontend AND in the editor
`block.front-only.js` - enqueued on the frontend but NOT on the editor.

I added options to enable/disable these in `init.php`. Both scripts are disabled by default, because most people probably won't need these. This part is not terribly elegant. Maybe there should be a little config file in the `src` where you can set these options?

This is similar to [mtthias's solution](https://github.com/mtthias/create-guten-block), but I simplified the webpack configs and tried to be more careful about preserving the existign formatting.

I tested this on WP 5.0 locally, and it was working. To test, I created a plugin with the the create-guten-block script and manually replaced the changed files in `src` and `node_modules`. I couldn't think of a better way to do this.

Tested start, build, and eject.