### PR TITLE
I18n

### DIFF
--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -55,7 +55,7 @@ function <% blockNamePHPLower %>_cgb_editor_assets() { // phpcs:ignore
 	// Param 1: JS handle
 	// Param 2: textdomain
 	if ( function_exists('wp_set_script_translations') ) {
-  	wp_set_script_translations( '<% blockNamePHPLower %>-cgb-block-js', '<% blockNamePHPLower %>' );
+  	wp_set_script_translations( '<% blockName % >-cgb-block-js', '<% blockName % >' );
   }	
 
 	// Styles.
@@ -75,6 +75,6 @@ add_action( 'enqueue_block_editor_assets', '<% blockNamePHPLower %>_cgb_editor_a
  * Set a Textdomain for i18n
  */
 function <% blockNamePHPLower %>_load_textdomain() {
-  load_plugin_textdomain( '<% blockNamePHPLower %>' );
+  load_plugin_textdomain( '<% blockName % >' );
 }
 add_action( 'plugins_loaded', '<% blockNamePHPLower %>_load_textdomain' );

--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -51,6 +51,13 @@ function <% blockNamePHPLower %>_cgb_editor_assets() { // phpcs:ignore
 		true // Enqueue the script in the footer.
 	);
 
+	// Send translations to JS files
+	// Param 1: JS handle
+	// Param 2: textdomain
+	if ( function_exists('wp_set_script_translations') ) {
+  	wp_set_script_translations( '<% blockNamePHPLower %>-cgb-block-js', '<% blockNamePHPLower %>' );
+  }	
+
 	// Styles.
 	wp_enqueue_style(
 		'<% blockNamePHPLower %>-cgb-block-editor-css', // Handle.
@@ -62,3 +69,12 @@ function <% blockNamePHPLower %>_cgb_editor_assets() { // phpcs:ignore
 
 // Hook: Editor assets.
 add_action( 'enqueue_block_editor_assets', '<% blockNamePHPLower %>_cgb_editor_assets' );
+
+
+/**
+ * Set a Textdomain for i18n
+ */
+function <% blockNamePHPLower %>_load_textdomain() {
+  load_plugin_textdomain( '<% blockNamePHPLower %>' );
+}
+add_action( 'plugins_loaded', '<% blockNamePHPLower %>_load_textdomain' );


### PR DESCRIPTION
Hi !

A small PR to handle i18n into CGB. 
It doesn't need a lot of things in order to work:

- a textdomain
- the news function wp_set_script_translation to send translations to JS file

Docs: 
https://make.wordpress.org/core/2018/11/09/new-javascript-i18n-support-in-wordpress/

I used <% blockName %> to auto generate textdomain name. I just hope it create a dashed separated name (but I think so, as it's already used for CSS).

Tell me if you see anything wrong.
Hope it's useful !



