### PR TITLE
css dependencies

### DIFF
--- a/examples/01-single-block/src/init.php
+++ b/examples/01-single-block/src/init.php
@@ -54,7 +54,7 @@ function single_block_cgb_editor_assets() {
 	wp_enqueue_style(
 		'single_block-cgb-block-editor-css', // Handle.
 		plugins_url( 'dist/blocks.editor.build.css', dirname( __FILE__ ) ), // Block editor CSS.
-		array( 'wp-edit-blocks' ) // Dependency to include the CSS after it.
+		array( 'wp-edit-blocks', 'single_block-cgb-style-css' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.editor.build.css' ) // Version: File modification time.
 	);
 }

--- a/examples/02-single-block-ejected/src/init.php
+++ b/examples/02-single-block-ejected/src/init.php
@@ -54,7 +54,7 @@ function single_block_cgb_editor_assets() {
 	wp_enqueue_style(
 		'single_block-cgb-block-editor-css', // Handle.
 		plugins_url( 'dist/blocks.editor.build.css', dirname( __FILE__ ) ), // Block editor CSS.
-		array( 'wp-edit-blocks' ) // Dependency to include the CSS after it.
+		array( 'wp-edit-blocks', 'single_block-cgb-style-css' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.editor.build.css' ) // Version: File modification time.
 	);
 } // End function single_block_cgb_editor_assets().

--- a/examples/03-multi-block/src/init.php
+++ b/examples/03-multi-block/src/init.php
@@ -54,7 +54,7 @@ function multi_block_cgb_editor_assets() {
 	wp_enqueue_style(
 		'multi_block-cgb-block-editor-css', // Handle.
 		plugins_url( 'dist/blocks.editor.build.css', dirname( __FILE__ ) ), // Block editor CSS.
-		array( 'wp-edit-blocks' ) // Dependency to include the CSS after it.
+		array( 'wp-edit-blocks', 'multi_block-cgb-style-css' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.editor.build.css' ) // Version: File modification time.
 	);
 } // End function multi_block_cgb_editor_assets().

--- a/examples/04-multi-block-ejected/src/init.php
+++ b/examples/04-multi-block-ejected/src/init.php
@@ -54,7 +54,7 @@ function multi_block_cgb_editor_assets() {
 	wp_enqueue_style(
 		'multi_block-cgb-block-editor-css', // Handle.
 		plugins_url( 'dist/blocks.editor.build.css', dirname( __FILE__ ) ), // Block editor CSS.
-		array( 'wp-edit-blocks' ) // Dependency to include the CSS after it.
+		array( 'wp-edit-blocks', 'multi_block-cgb-style-css' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.editor.build.css' ) // Version: File modification time.
 	);
 } // End function multi_block_cgb_editor_assets().

--- a/examples/05-a11y-input/src/init.php
+++ b/examples/05-a11y-input/src/init.php
@@ -55,7 +55,7 @@ function a11y_input_cgb_editor_assets() {
 	wp_enqueue_style(
 		'a11y_input-cgb-block-editor-css', // Handle.
 		plugins_url( 'dist/blocks.editor.build.css', dirname( __FILE__ ) ), // Block editor CSS.
-		array( 'wp-edit-blocks' ) // Dependency to include the CSS after it.
+		array( 'wp-edit-blocks', 'a11y_input-cgb-style-css' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.editor.build.css' ) // Version: File modification time.
 	);
 } // End function a11y_input_cgb_editor_assets().

--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -55,7 +55,7 @@ function <% blockNamePHPLower %>_cgb_editor_assets() { // phpcs:ignore
 	wp_enqueue_style(
 		'<% blockNamePHPLower %>-cgb-block-editor-css', // Handle.
 		plugins_url( 'dist/blocks.editor.build.css', dirname( __FILE__ ) ), // Block editor CSS.
-		array( 'wp-edit-blocks' ) // Dependency to include the CSS after it.
+		array( 'wp-edit-blocks', '<% blockNamePHPLower %>-cgb-style-css' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.editor.build.css' ) // Version: File modification time.
 	);
 }


### PR DESCRIPTION
Make the editor.css load after style.css

`dist/blocks.editor.build.css`should load after `dist/blocks.style.build.css` to override any styles in the Editor.
Adding the "style.css" as dependency achieve that.

