### PR TITLE
Add @wordpress/hooks as an available external

### DIFF
--- a/packages/cgb-scripts/config/externals.js
+++ b/packages/cgb-scripts/config/externals.js
@@ -24,6 +24,7 @@ const externals = [
 	'plugins',
 	'editor',
 	'blocks',
+	'hooks',
 	'utils',
 	'date',
 	'data',


### PR DESCRIPTION
When implementing a block, it would be helpful to have access to the `applyFilters` and `withFilters` provided by Gutenberg.

For example:

```
import {
	applyFilters,
} from '@wordpress/hooks';

const getSomething = function() {
	return applyFilters( 'blocks.myBlock.getSomething', 'defaultvalue' );
}
```
