### PR TITLE
Add blocks-frontend.js for blocks frontend scripts

### DIFF
--- a/packages/cgb-scripts/config/paths.js
+++ b/packages/cgb-scripts/config/paths.js
@@ -16,6 +16,7 @@ module.exports = {
 	dotenv: resolvePlugin( '.env' ),
 	pluginSrc: resolvePlugin( 'src' ), // Plugin src folder path.
 	pluginBlocksJs: resolvePlugin( 'src/blocks.js' ),
+	pluginBlocksFrontendJs: resolvePlugin( 'src/blocks-frontend.js' ),
 	yarnLockFile: resolvePlugin( 'yarn.lock' ),
 	pluginDist: resolvePlugin( '.' ), // We are in ./dist folder already so the path '.' resolves to ./dist/.
 };
@@ -28,6 +29,7 @@ module.exports = {
 	dotenv: resolvePlugin( '.env' ),
 	pluginSrc: resolvePlugin( 'src' ),
 	pluginBlocksJs: resolvePlugin( 'src/blocks.js' ),
+	pluginBlocksFrontendJs: resolvePlugin( 'src/blocks-frontend.js' ),
 	pluginDist: resolvePlugin( '.' ), // We are in ./dist folder already so the path '.' resolves to ./dist/.
 	yarnLockFile: resolvePlugin( 'yarn.lock' ),
 	appPath: resolvePlugin( '.' ),

--- a/packages/cgb-scripts/config/webpack.config.dev.js
+++ b/packages/cgb-scripts/config/webpack.config.dev.js
@@ -73,6 +73,7 @@ const extractConfig = {
 module.exports = {
 	entry: {
 		'./dist/blocks.build': paths.pluginBlocksJs, // 'name' : 'path/file.ext'.
+		'./dist/frontend.blocks.build' : paths.pluginBlocksFrontendJs, // 'name' : 'path/file.ext'.
 	},
 	output: {
 		// Add /* filename */ comments to generated require()s in the output.

--- a/packages/cgb-scripts/config/webpack.config.prod.js
+++ b/packages/cgb-scripts/config/webpack.config.prod.js
@@ -77,6 +77,7 @@ const extractConfig = {
 module.exports = {
 	entry: {
 		'./dist/blocks.build': paths.pluginBlocksJs, // 'name' : 'path/file.ext'.
+		'./dist/frontend.blocks.build' : paths.pluginBlocksFrontendJs, // 'name' : 'path/file.ext'.
 	},
 	output: {
 		// Add /* filename */ comments to generated require()s in the output.

--- a/packages/cgb-scripts/template/src/blocks-frontend.js
+++ b/packages/cgb-scripts/template/src/blocks-frontend.js
@@ -1,0 +1,1 @@
+// Blocks frontend scripts

--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -27,6 +27,14 @@ function <% blockNamePHPLower %>_cgb_block_assets() { // phpcs:ignore
 		array( 'wp-editor' ) // Dependency to include the CSS after it.
 		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.style.build.css' ) // Version: File modification time.
 	);
+	// Scripts.
+	wp_enqueue_script(
+		'<% blockNamePHPLower %>-cgb-blocks-frontend-js', // Handle.
+		plugins_url( '/dist/frontend.blocks.build.js', dirname( __FILE__ ) ), // frontend.blocks.build.js: We register the frontend scripts for block here. Built with Webpack.
+		array(), // Dependencies, defined above.
+		// filemtime( plugin_dir_path( __DIR__ ) . 'dist/frontend.blocks.build.js' ), // Version: File modification time.
+		true // Enqueue the script in the footer.
+	);
 }
 
 // Hook: Frontend assets.


### PR DESCRIPTION
Why we need blocks-frontend.js file and what problem it will solve?
To run scripts on front-end with src/blocks.js you can only run scripts in the admin area. 

For example, I created testimonial carousel block to make carousel run in the admin area and on front-end I have to call the carousel js plugin both on front-end and backend. 
![image](https://user-images.githubusercontent.com/32260742/50710601-2e9d3a80-108d-11e9-8b1b-5c162768f036.png)


That's why blocks-frontend.js file is necessary to be in the great toolkit.

