### PR TITLE
🐛 Add lodash dependency

### DIFF
--- a/packages/cgb-scripts/config/externals.js
+++ b/packages/cgb-scripts/config/externals.js
@@ -41,7 +41,7 @@ const externals = [
 		react: 'React', // React itself is there in Gutenberg.
 		jquery: 'jQuery', // import $ from 'jquery' // Use the WordPress version after enqueuing it.
 		'react-dom': 'ReactDOM',
-		lodash: 'lodash', // Lodash is there in Gutenberg
+		lodash: 'lodash', // Lodash is there in Gutenberg.
 	}
 );
 

--- a/packages/cgb-scripts/config/externals.js
+++ b/packages/cgb-scripts/config/externals.js
@@ -41,6 +41,7 @@ const externals = [
 		react: 'React', // React itself is there in Gutenberg.
 		jquery: 'jQuery', // import $ from 'jquery' // Use the WordPress version after enqueuing it.
 		'react-dom': 'ReactDOM',
+		lodash: 'lodash', // Lodash is there in Gutenberg
 	}
 );
 


### PR DESCRIPTION
I think this should fix ahmadawais/create-guten-block#124.

- `window.lodash` is already present in Gutenberg. 
- `window._` is underscore (not lodash, they differ only in some small details, but sometimes these do matter).
- If you import `lodash` in the code, it will override `window._` with lodash, which will cause weird bugs in totally unrelated places. This happens if you import some of the `@wordpress` Gutenberg modules.

Adding lodash here will prevent webpack from including `lodash` in the output, so it won't cause any conflicts. 

### How to test this
ahmadawais/create-guten-block#124 only happend on my system, if I installed some other plugins. The easiest way to reproduce it, is to install the `TinyMCE Advanced` plugin. 

In your block code: 
Add `import { compose } from "@wordpress/compose";` to one of the JavaScript files.

`@wordpress/compose` exports `flowRight` from `lodash` as `compose`, so it imports `lodash`. 
This will cause lodash to be included in your build. 

I created a minimal repository to show this: https://github.com/martinstuecklschwaiger/gutenberg-example