### PR TITLE
🐛FIX: typo

### DIFF
--- a/packages/create-guten-block/app/npmInstallScripts.js
+++ b/packages/create-guten-block/app/npmInstallScripts.js
@@ -45,7 +45,7 @@ module.exports = ( blockName, blockDir ) => {
 			'cgb-scripts',
 			'--save',
 			'--save-exact',
-			'--slient',
+			'--silent',
 		] );
 		resolve( true );
 	} );


### PR DESCRIPTION
npm does not have a `--slient` flag. However, it does have a `--silent` one.