### PR TITLE
👌 IMPROVE: Prevent name collisions by using random numbers

### DIFF
--- a/packages/cgb-scripts/scripts/init.js
+++ b/packages/cgb-scripts/scripts/init.js
@@ -22,6 +22,17 @@ process.on( 'unhandledRejection', err => {
 } );
 
 /**
+ * Generate a positive random integer value.
+ *
+ * @return {number}
+ */
+const generateRandomInt = () => {
+	const max = Math.pow(2, 53) - 1; // Number.MAX_SAFE_INTEGER
+	return Math.floor(Math.random() * max);
+};
+
+
+/**
  * Copy template to the plugin dir.
  *
  * @param {string} blockName The block name.
@@ -53,6 +64,8 @@ const copyTemplateFiles = ( blockName, blockDir, blockNamePHPLower, blockNamePHP
 
 		// console.log( '\n\nLIST OF FILES', files, '\n\n' );
 
+		const blockRandomInt = generateRandomInt();
+
 		// Replace dynamic content for block name in the code.
 		files.forEach( function( file ) {
 			shell.sed( '-i', '<% blockName %>', `${ blockName }`, file );
@@ -61,6 +74,8 @@ const copyTemplateFiles = ( blockName, blockDir, blockNamePHPLower, blockNamePHP
 			shell.sed( '-i', '<% blockNamePHPLower % >', `${ blockNamePHPLower }`, file );
 			shell.sed( '-i', '<% blockNamePHPUpper %>', `${ blockNamePHPUpper }`, file );
 			shell.sed( '-i', '<% blockNamePHPUpper % >', `${ blockNamePHPUpper }`, file );
+			shell.sed( '-i', '<% blockRandomInt %>', `${ blockRandomInt }`, file );
+			shell.sed( '-i', '<% blockRandomInt % >', `${ blockRandomInt }`, file );
 		} );
 
 		resolve( true );

--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @uses {wp-editor} for WP editor styles.
  * @since 1.0.0
  */
-function <% blockNamePHPLower %>_cgb_block_assets() { // phpcs:ignore
+function cgb_block_assets_<% blockRandomInt %>() { // phpcs:ignore
 	// Styles.
 	wp_enqueue_style(
 		'<% blockNamePHPLower %>-cgb-style-css', // Handle.
@@ -30,7 +30,7 @@ function <% blockNamePHPLower %>_cgb_block_assets() { // phpcs:ignore
 }
 
 // Hook: Frontend assets.
-add_action( 'enqueue_block_assets', '<% blockNamePHPLower %>_cgb_block_assets' );
+add_action( 'enqueue_block_assets', 'cgb_block_assets_<% blockRandomInt %>' );
 
 /**
  * Enqueue Gutenberg block assets for backend editor.
@@ -41,7 +41,7 @@ add_action( 'enqueue_block_assets', '<% blockNamePHPLower %>_cgb_block_assets' )
  * @uses {wp-editor} for WP editor styles.
  * @since 1.0.0
  */
-function <% blockNamePHPLower %>_cgb_editor_assets() { // phpcs:ignore
+function cgb_editor_assets_<% blockRandomInt %>() { // phpcs:ignore
 	// Scripts.
 	wp_enqueue_script(
 		'<% blockNamePHPLower %>-cgb-block-js', // Handle.
@@ -61,4 +61,4 @@ function <% blockNamePHPLower %>_cgb_editor_assets() { // phpcs:ignore
 }
 
 // Hook: Editor assets.
-add_action( 'enqueue_block_editor_assets', '<% blockNamePHPLower %>_cgb_editor_assets' );
+add_action( 'enqueue_block_editor_assets', 'cgb_editor_assets_<% blockRandomInt %>' );


### PR DESCRIPTION
If different plugins both use cgb and create a block with the same name, this would otherwise create a name collision.

Note that this is not the same as registering a block with the same name in JS:
- PHP functions with the same name will crash in PHP
- People might change the name of the registered JS block, but might keep the old function names in `init.php` (this already happened to me and a different plugin author, we both initially called our block `block`).

<!--
Thank you for sending a PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots! I mean that.

Happy contributing!
-->
