### PR TITLE
🐛 FIX: Exclude i18n functions from Uglify for translations.

### DIFF
--- a/packages/cgb-scripts/config/webpack.config.prod.js
+++ b/packages/cgb-scripts/config/webpack.config.prod.js
@@ -134,6 +134,7 @@ module.exports = {
 			},
 			mangle: {
 				safari10: true,
+				except: ['__', '_n', '_x', '_nx' ],
 			},
 			output: {
 				comments: false,


### PR DESCRIPTION
I added the i18n functions as exclusions for when running ```npm run build```. This allows the JavaScript functions to be translated with WP CLI makepot.

For example:

After running ```npm run build```, you can run WP CLI and it will read the JavaScript translation strings.

```bash 
Huereca:wp-plugin-info-card jasonandrews$ wp i18n make-pot . langs/wp-plugin-info-card.pot
```

And here's some sample POT output:

```
#: src/wp-plugin-info-card-ui.php:32
#: dist/blocks.build.js:1
msgid "Large"
msgstr ""

#: src/wp-plugin-info-card-ui.php:33
#: dist/blocks.build.js:1
msgid "WordPress"
msgstr ""
```
