### PR TITLE
 📦 NEW: The wp_localize_script functionality

### DIFF
--- a/packages/cgb-scripts/config/externals.js
+++ b/packages/cgb-scripts/config/externals.js
@@ -32,7 +32,7 @@ const externals = [
 ].reduce(
 	( externals, name ) => ( {
 		...externals,
-		[ `@wordpress/${name}` ]: `wp.${ camelCaseDash( name ) }`,
+		[ `@wordpress/${ name }` ]: `wp.${ camelCaseDash( name ) }`,
 	} ),
 	{
 		wp: 'wp',

--- a/packages/cgb-scripts/config/externals.js
+++ b/packages/cgb-scripts/config/externals.js
@@ -1,7 +1,7 @@
 /**
  * Utility methods for use when generating build configuration objects.
  */
-const { join } = require( 'path' );
+const { join } = require('path');
 
 /**
  * Given a string, returns a new string with dash separators converted to
@@ -12,7 +12,7 @@ const { join } = require( 'path' );
  *
  * @return {string} Camel-cased string.
  */
-const camelCaseDash = string => string.replace( /-([a-z])/g, ( match, letter ) => letter.toUpperCase() );
+const camelCaseDash = string => string.replace(/-([a-z])/g, (match, letter) => letter.toUpperCase());
 
 /**
  * Define externals to load components through the wp global.
@@ -28,12 +28,12 @@ const externals = [
 	'utils',
 	'date',
 	'data',
-	'i18n',
+	'i18n'
 ].reduce(
-	( externals, name ) => ( {
+	(externals, name) => ({
 		...externals,
-		[ `@wordpress/${ name }` ]: `wp.${ camelCaseDash( name ) }`,
-	} ),
+		[`@wordpress/${name}`]: `wp.${camelCaseDash(name)}`
+	}),
 	{
 		wp: 'wp',
 		ga: 'ga', // Old Google Analytics.
@@ -42,6 +42,7 @@ const externals = [
 		jquery: 'jQuery', // import $ from 'jquery' // Use the WordPress version after enqueuing it.
 		'react-dom': 'ReactDOM',
 		lodash: 'lodash', // Lodash is there in Gutenberg.
+		cgbdata: 'CGB_DATA' // Plugin path and url.
 	}
 );
 

--- a/packages/cgb-scripts/config/externals.js
+++ b/packages/cgb-scripts/config/externals.js
@@ -42,7 +42,7 @@ const externals = [
 		jquery: 'jQuery', // import $ from 'jquery' // Use the WordPress version after enqueuing it.
 		'react-dom': 'ReactDOM',
 		lodash: 'lodash', // Lodash is there in Gutenberg.
-		cgbdata: 'CGB_DATA', // Plugin path and url.
+		CGB_GLOBAL: 'CGB_GLOBAL' // Add custom dynamic data to a global var.
 	}
 );
 

--- a/packages/cgb-scripts/config/externals.js
+++ b/packages/cgb-scripts/config/externals.js
@@ -1,7 +1,7 @@
 /**
  * Utility methods for use when generating build configuration objects.
  */
-const { join } = require('path');
+const { join } = require( 'path' );
 
 /**
  * Given a string, returns a new string with dash separators converted to
@@ -12,7 +12,7 @@ const { join } = require('path');
  *
  * @return {string} Camel-cased string.
  */
-const camelCaseDash = string => string.replace(/-([a-z])/g, (match, letter) => letter.toUpperCase());
+const camelCaseDash = string => string.replace( /-([a-z])/g, ( match, letter ) => letter.toUpperCase() );
 
 /**
  * Define externals to load components through the wp global.
@@ -28,12 +28,12 @@ const externals = [
 	'utils',
 	'date',
 	'data',
-	'i18n'
+	'i18n',
 ].reduce(
-	(externals, name) => ({
+	( externals, name ) => ( {
 		...externals,
-		[`@wordpress/${name}`]: `wp.${camelCaseDash(name)}`
-	}),
+		[ `@wordpress/${name}` ]: `wp.${ camelCaseDash( name ) }`,
+	} ),
 	{
 		wp: 'wp',
 		ga: 'ga', // Old Google Analytics.
@@ -42,7 +42,7 @@ const externals = [
 		jquery: 'jQuery', // import $ from 'jquery' // Use the WordPress version after enqueuing it.
 		'react-dom': 'ReactDOM',
 		lodash: 'lodash', // Lodash is there in Gutenberg.
-		cgbdata: 'CGB_DATA' // Plugin path and url.
+		cgbdata: 'CGB_DATA', // Plugin path and url.
 	}
 );
 

--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -56,11 +56,11 @@ function <% blockNamePHPLower %>_cgb_block_assets() { // phpcs:ignore
 	// Localise globals - plugin path and url for use in blocks.
 	wp_localize_script(
 		'<% blockNamePHPLower %>-cgb-block-js',
-		'CGB_DATA', // Array containing the globals.
-		array(
+		'CGB_GLOBAL', // Array containing dynamic data for a JS Global.
+		[
 			'path' => plugin_dir_path( __FILE__ ),
 			'url'  => plugin_dir_url( __FILE__ ),
-		)
+		]
 	);
 
 	/**

--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -55,7 +55,7 @@ function <% blockNamePHPLower %>_cgb_block_assets() { // phpcs:ignore
 
 	// Localise globals - plugin path and url for use in blocks.
 	wp_localize_script(
-		'-cgb-block-js',
+		'<% blockNamePHPLower %>-cgb-block-js',
 		'CGB_DATA', // Array containing the globals.
 		array(
 			'path' => plugin_dir_path( __FILE__ ),

--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -53,6 +53,16 @@ function <% blockNamePHPLower %>_cgb_block_assets() { // phpcs:ignore
 		null // filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.editor.build.css' ) // Version: File modification time.
 	);
 
+	// Localise globals - plugin path and url for use in blocks.
+	wp_localize_script(
+		'-cgb-block-js',
+		'CGB_DATA', // Array containing the globals.
+		array(
+			'path' => plugin_dir_path( __FILE__ ),
+			'url'  => plugin_dir_url( __FILE__ ),
+		)
+	);
+
 	/**
 	 * Register Gutenberg block on server-side.
 	 *


### PR DESCRIPTION
This PR adds `wp_localize_script` in the CGB template.

**Problem**
You can not determine the path or URL of the plugin programatically inside the blocks. This is usually done by PHP functions plugin_dir_path() and plugin_dir_url(). However, they are not accessible inside the blocks (say if one wants to include an image locally and link to it in the src tag).

**Solution**
 In this PR, I have added an array `CGB_GLOBAL` containing dynamic data for a JS Global. The globals can now be imported inside the block JS file. More useful globals can be added in the future.