### PR TITLE
🐛 FIX: Add `block-editor` to externals

### DIFF
--- a/packages/cgb-scripts/config/externals.js
+++ b/packages/cgb-scripts/config/externals.js
@@ -23,6 +23,7 @@ const externals = [
 	'element',
 	'plugins',
 	'editor',
+	'block-editor',
 	'blocks',
 	'hooks',
 	'utils',


### PR DESCRIPTION
Some things (e.g. `InspectorControls`) in `editor` are deprecated and should be used from `block-editor`.

<!--
Thank you for sending a PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots! I mean that.

Happy contributing!
-->
