### PR TITLE
📦 NEW: @wordpress/api-fetch as an available external

### DIFF
--- a/packages/cgb-scripts/config/externals.js
+++ b/packages/cgb-scripts/config/externals.js
@@ -19,6 +19,7 @@ const camelCaseDash = string => string.replace( /-([a-z])/g, ( match, letter ) =
  */
 const externals = [
 	'components',
+	'api-fetch',
 	'edit-post',
 	'element',
 	'plugins',


### PR DESCRIPTION
Allows using the external wp.apiFetch method. Otherwise, if you try to import it from the @wordpress/api-fetch package, it won't have the REST API base URL initialized.

Example of usage:

import apiFetch from '@wordpress/api-fetch';
 
apiFetch( { path: '/wp/v2/posts' } ).then( posts => {
    console.log( posts );
} );