### PR TITLE
👌 IMPROVE: Styles from wp-editor with context

### DIFF
--- a/packages/cgb-scripts/template/src/init.php
+++ b/packages/cgb-scripts/template/src/init.php
@@ -32,7 +32,7 @@ function <% blockNamePHPLower %>_cgb_block_assets() { // phpcs:ignore
 	wp_register_style(
 		'<% blockNamePHPLower %>-cgb-style-css', // Handle.
 		plugins_url( 'dist/blocks.style.build.css', dirname( __FILE__ ) ), // Block style CSS.
-		array( 'wp-editor' ), // Dependency to include the CSS after it.
+		is_admin() ? array( 'wp-editor' ) : null, // Dependency to include the CSS after it.
 		null // filemtime( plugin_dir_path( __DIR__ ) . 'dist/blocks.style.build.css' ) // Version: File modification time.
 	);
 


### PR DESCRIPTION
Only add `wp-editor` as block CSS dependency when in admin context, in order to avoid WordPress enqueuing additional backend CSS in the frontend leading to unnecessary requests.

This addresses issue ahmadawais/create-guten-block#160.