### PR TITLE
Check if file exists before attempting to read

### DIFF
--- a/packages/cgb-scripts/scripts/build.js
+++ b/packages/cgb-scripts/scripts/build.js
@@ -46,6 +46,9 @@ const fileStyleCSS = path.resolve( theCWD, './dist/blocks.style.build.css' );
  * @returns {string} then size result.
  */
 const getFileSize = filePath => {
+	if ( ! fs.existsSync( filePath ) ) {
+		return fileSize( 0 );
+	}
 	return fileSize( gzipSize.sync( fs.readFileSync( filePath ) ) );
 };
 


### PR DESCRIPTION
Avoids error when there file does not exist (eg: there's no editor styles).
